### PR TITLE
Fix endpoint for getting translations

### DIFF
--- a/QuranApi/lib/quran_api_web/controllers/quotes_controller.ex
+++ b/QuranApi/lib/quran_api_web/controllers/quotes_controller.ex
@@ -9,8 +9,7 @@ defmodule QuranApiWeb.QuotesController do
   end
 
   def get_quote_with_translation(conn, %{"id" => id}) do
-    translation = conn.params["translation"] || "bs"
-
+    translation = Map.get(conn.params, "translation", "bs")
     quote_with_translation = Quotes.get_quote_with_translation!(id, translation)
 
     render(conn, "show_translate.json", %{

--- a/QuranApi/lib/quran_api_web/controllers/quotes_json.ex
+++ b/QuranApi/lib/quran_api_web/controllers/quotes_json.ex
@@ -1,5 +1,4 @@
 defmodule QuranApiWeb.QuotesJSON do
-
   def show(%{quote: quote}) do
     %{data: data_quote_minimal(quote)}
   end

--- a/QuranApi/lib/quran_api_web/router.ex
+++ b/QuranApi/lib/quran_api_web/router.ex
@@ -9,7 +9,7 @@ defmodule QuranApiWeb.Router do
     pipe_through :api
 
     get "/quotes", QuotesController, :get_random_quote
-    post "/quotes/:id", QuotesController, :get_quote_with_translation
+    get "/quotes/:id", QuotesController, :get_quote_with_translation
   end
 
   # Enable Swoosh mailbox preview in development


### PR DESCRIPTION
This pull request includes updates to the `QuotesController`, `QuotesJSON`, and `Router` modules in the `QuranApi` project. The changes improve code readability, fix a routing method, and streamline parameter handling.

**Controller improvements:**
- [`QuranApi/lib/quran_api_web/controllers/quotes_controller.ex`](diffhunk://#diff-3ef6ef0b81d8d87ee0c5562a776193add95c7d76dbbce4b86bdb3984a0a93677L12-R12): Replaced the manual parameter fallback logic with `Map.get` for cleaner and more idiomatic handling of the `translation` parameter.

**Routing fixes:**
- [`QuranApi/lib/quran_api_web/router.ex`](diffhunk://#diff-8e27dbc738d5fa5d5b22b6e55807aa1d156a6203f46ebf831ebbed0085a0f128L12-R12): Changed the HTTP method for the `/quotes/:id` route from `POST` to `GET` to align with RESTful conventions.

**Code cleanup:**
- [`QuranApi/lib/quran_api_web/controllers/quotes_json.ex`](diffhunk://#diff-e54f3d3e94d63d0cb93b66bd85963722a4df66d652517e1d9bba52b7c9da77deL2): Removed an unnecessary blank line for better formatting consistency.Fix the endpoint for getting translations like in openapi spec.