### PR TITLE
Add GitHub workflows for build, test, and format

### DIFF
--- a/.github/workflows/build_test_foramt_pipeline.yaml
+++ b/.github/workflows/build_test_foramt_pipeline.yaml
@@ -1,0 +1,64 @@
+name: Build, Test, and Format
+
+on:
+    push:
+        branches: [ main ]
+    pull_request:
+        branches: [ main ]
+
+env:
+  MIX_ENV: test
+defaults:
+  run:
+    # Define the default working-directory for all run steps
+    working-directory: QuranApi
+jobs:
+  test-QuranApi:
+    name: Build and test QuranApi
+    runs-on: ubuntu-22.04
+    services:
+      postgres:
+        image: postgres:16.6
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+        - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v4
+
+    - name: Install OTP and Elixir
+      uses: erlef/setup-beam@v1
+      id: beam
+      with:
+        version-file: QuranApi/.tool-versions
+        version-type: strict
+
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v4
+      with:
+        path: |
+          QuranApi/deps
+          QuranApi/_build
+        key: "${{ runner.os }}-\
+              otp-${{ steps.beam.outputs.otp-version }}-\
+              elixir-${{ steps.beam.outputs.elixir-version }}-\
+              ${{ hashFiles('QuranApi/mix.lock') }}"
+
+    - name: Install and compile dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+        mix deps.get --only test
+        mix deps.compile
+    - name: Check formatting
+      run: mix format --check-formatted
+    - name: Compile
+      run: mix compile
+    - name: Test
+      run: mix test

--- a/QuranApi/.tool-versions
+++ b/QuranApi/.tool-versions
@@ -1,0 +1,3 @@
+erlang 27.3
+elixir 1.18.2-otp-27
+postgres 16.6


### PR DESCRIPTION
This pull request introduces a CI/CD pipeline for the `QuranApi` project and updates the `.tool-versions` file to specify the required versions of Erlang, Elixir, and PostgreSQL. The pipeline automates build, test, and formatting checks, ensuring consistent development practices.

### CI/CD Pipeline Setup:

* [`.github/workflows/build_test_foramt_pipeline.yaml`](diffhunk://#diff-288f86083946c4b61e68c327d4582a3c48b175f9bc367e5b6a93064875aaabc7R1-R64): Added a GitHub Actions workflow to automate the build, test, and format checks for the `QuranApi` project. The workflow includes steps for cloning the repository, setting up the environment, caching dependencies, compiling the code, checking formatting, and running tests. It also configures a PostgreSQL service for testing.

### Tool Version Specification:

* [`QuranApi/.tool-versions`](diffhunk://#diff-6857ef5a5a161a12f5914aa3aa05c5759ba12a4a2c2cd5fed8ca480dc18653d9R1-R3): Defined specific versions of Erlang (`27.3`), Elixir (`1.18.2-otp-27`), and PostgreSQL (`16.6`) required for the project.